### PR TITLE
Add support for **/*.ext patterns

### DIFF
--- a/filepathx.go
+++ b/filepathx.go
@@ -26,6 +26,11 @@ func Glob(pattern string) ([]string, error) {
 func (globs Globs) Expand() ([]string, error) {
 	var matches = []string{""} // accumulate here
 	for _, glob := range globs {
+		if glob == "" {
+			// If the glob is empty string that means it was **
+			// By setting this to . patterns like **/*.txt are supported
+			glob = "."
+		}
 		var hits []string
 		var hitMap = map[string]bool{}
 		for _, match := range matches {


### PR DESCRIPTION
Hey

Wanted to make a small PR to support patterns like `**/*.ts` or any extension which was previously not working.

It is a very simple fix by just checking if the `glob` is an empty string 