### PR TITLE
Fix single star into double star

### DIFF
--- a/filepathx.go
+++ b/filepathx.go
@@ -29,7 +29,7 @@ func (globs Globs) Expand() ([]string, error) {
 		var hits []string
 		var hitMap = map[string]bool{}
 		for _, match := range matches {
-			paths, err := filepath.Glob(match + glob)
+			paths, err := filepath.Glob(filepath.Join(match, glob))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Single star into double star did not work as expected.

Pattern `a/b/*/e.f/**` would not match `a/b/c/e.f/g` since the top level glob would be performed on a path ending with a `/`. Using `filepath.Join(match, glob)` will remove the trailing slash.

Two tests included for regression tests. And as a side bonus tests will now also pass on Windows.